### PR TITLE
fix: xr rig documentation

### DIFF
--- a/docfx/articles/core/quick-start.md
+++ b/docfx/articles/core/quick-start.md
@@ -30,13 +30,9 @@ By looking at the other objects in the scene, we can see that some have a `Proce
 
 If these properties are not added manually you will usually be prompted to add them automatically when building the process of your VR application.
 
-### Customizing the Rig
+### The Rig
 
-When creating a VR Builder scene, the default rig is created directly in the scene and can be edited or replaced like any game object. If you plan to use the same rig in multiple scenes, just create a prefab of it and manually replace the default rig.
-
-The only requirement every VR Builder rig has, independent of the interaction system, is that it must contain a `User Scene Object` component. This component identifies the rig as the user, and is usually placed on the root of the rig. It should reference the head, hand and base transforms, so that VR Builder can access those positions when needed. If left empty, it will attempt to find the head by itself by looking for the camera's transform.
-
-It is also possible to add other `Process Scene Object`s on the rig in order to use hands, backpacks, toolbelts and so on in behaviors and conditions, depending on the use case.
+When creating a VR Builder scene, the default rig is created directly in the scene and can be edited or replaced like any game object. Find more about rig customization in the [XR Rig](xr-rig.md) article.
 
 ### Process Editor
 

--- a/docfx/articles/core/quick-start.md
+++ b/docfx/articles/core/quick-start.md
@@ -32,7 +32,7 @@ If these properties are not added manually you will usually be prompted to add t
 
 ### The Rig
 
-When creating a VR Builder scene, the default rig is created directly in the scene and can be edited or replaced like any game object. Find more about rig customization in the [XR Rig](xr-rig.md) article.
+When creating a VR Builder scene, the default rig is created directly in the scene and can be edited or replaced like any game object. Learn more about rig customization in the [XR Rig](xr-rig.md) article.
 
 ### Process Editor
 

--- a/docfx/articles/core/xr-rig.md
+++ b/docfx/articles/core/xr-rig.md
@@ -2,6 +2,14 @@
 
 The XR Rig is a game object that anchors the user’s head mounted display, controllers, or user’s hands when using hand tracking within the virtual space. Essentially, it represents the user in the scene. On the rig, you can configure which types of locomotion and interaction are available to the user.
 
+### Customizing the Rig
+
+If you plan to use the same rig in multiple scenes, just create a prefab of it and manually replace the default rig.
+
+The only requirement every VR Builder rig has, independent of the interaction system, is that it must contain a `User Scene Object` component. This component identifies the rig as the user, and is usually placed on the root of the rig. It should reference the head, hand and base transforms, so that VR Builder can access those positions when needed. If left empty, it will attempt to find the head by itself by looking for the camera's transform.
+
+It is also possible to add other `Process Scene Object`s on the rig in order to use hands, backpacks, toolbelts and so on in behaviors and conditions, depending on the use case.
+
 ### VR Builder XR Rig
 
 When creating a new scene with the VR Builder Scene Setup Wizard, you get a `VRB_XR_Setup` game object automatically added to the scene. `VRB_XR_Setup` is the VR Builder XR Rig and is built upon the suggested standards set by the Unity XR Interaction Toolkit. Therefore, `VRB_XR_Setup` is very similar to the `XR Origin (XR Rig)` found in the XR Interaction Toolkit samples but has some additional VR Builder–specific scripts added.


### PR DESCRIPTION
## Summary

- Move rig customization details from the quick start page into the dedicated XR Rig article.
- Replace duplicated quick-start content with a link to the XR Rig article.

## Reason

VRB-3665 consolidates XR Rig documentation so rig customization guidance lives in the article dedicated to XR Rig setup and behavior.

## Impact

Readers get the quick-start flow without extended rig details, and the XR Rig page now contains the full customization guidance.

## Validation

- `git diff --check origin/develop...HEAD`
- `docfx build docfx.json --output ..\..\Temp\docfx-pr-check` succeeded with 0 errors and 1 existing template warning: no template processing for document type `cover`.